### PR TITLE
Update ~save and ~list functions. Make Waggles Image Directory a constant class field.

### DIFF
--- a/Commands/fileaccess.cs
+++ b/Commands/fileaccess.cs
@@ -110,6 +110,7 @@ public class Vtick : ModuleBase<SocketCommandContext>
         files = files.Select(file => Path.GetFileNameWithoutExtension(file)).ToArray();
         // Sort filenames alphabetically!
         Array.Sort(files, StringComparer.InvariantCulture);
+        // TODO: Save above results to a TXT file, and serve the file instead if the results get too large (above 2000 characters).
         await ReplyAsync(String.Join(" ", files));
     }
     


### PR DESCRIPTION
What the commit message says.

This also requires the branch to be checked out and tested prior to accepting the request. Just to make sure we don't commit any new bugs.

Testing should require:

- `~list` still lists all files.
- `~search` still works once.
- `~save` still works:
  - Trying to save over an existing file (shouldn't work)
  - Trying to save a file that isn't a valid image type (like .docx, shouldn't work)
  - Trying to save a file that IS valid (image.jpg, SHOULD work)

