### PR TITLE
 Added '~reverse URL', and overhauled ~derpi and ~next.

### DIFF
--- a/Commands/derpiCommands.cs
+++ b/Commands/derpiCommands.cs
@@ -174,7 +174,7 @@ public class DerpibooruComms : ModuleBase<SocketCommandContext>
         }
 
         // The `~next` command is basically `~next {CurrentIndex + 1}`, lets treat it that way.
-        await DerpiNextPick(++Global.searched);
+        await DerpiNextPick(Global.searched++);
     }
 
     // Allows you to select an item on the page of results by index number.
@@ -198,6 +198,10 @@ public class DerpibooruComms : ModuleBase<SocketCommandContext>
             // No Results Message.
             await ReplyAsync("No results! The tag may be misspelled, or the results could be filtered out due to channel!");
             return;
+        } else if (DerpiResponse.Search.Count() == 1) {
+            // Only a single result, no pagination.
+            await ReplyAsync("Only a single result in this image set.\n");
+            // No return, let it continue to parsing the image below.
         } else if (index < 0 || index >= DerpiResponse.Search.Count()) {
             // Out of Bounds Message.
             await ReplyAsync("Your selection is out of range! Valid values are between 0 and " + (DerpiResponse.Search.Count() - 1));
@@ -980,7 +984,7 @@ public class DerpiHelper {
     // TODO: ADD BETTER DOCUMENT/SUMMARY.
     // Check if a Derpibooru Search result is SFW, by way of scanning for a "safe" tag.
     public static bool IsElementSafe(DerpiSearch element) {
-        foreach (string tag in element.tags.Split(',')) {
+        foreach (string tag in element.tags.Split(",")) {
             // If a "safe" tag is found, return true.
             if (tag.Trim().Equals("safe")) {
                 return true;


### PR DESCRIPTION
**What was updated:**
- `~derpi`, both sorted and unsorted varieties. 
- `~next`, both default and specified index varieties.
- Added a `~reverse` command that takes a URL.

**How to test:**
- Ensure `~next` without a `~derpi` gives a friendly error message.
- Make sure `~derpi` works correctly still.
  - Test without artist, 1 artist, Multiple artist cases, and Screenshots.
- Make sure `~next` pages through results fine still.
- Make sure `~next INDEX` provides a consistent result.
- Test `~next` when out of bounds, like `~next 100`.
- Ensure new `~reverse URL` command works.
  - All Image cases work: Not Found, Found Offsite, Found Onsite
  - Safety settings are adhered to.
    - Reverse on NSFW channels always works.
    - Reverse on SFW channels will only show SFW results, displays a message if it finds a NSFW image result on a SFW channel.

**`~reverse` Image Test Cases:**
  - Not on Derpibooru result: `https://www.waggles.org/img/octaneRym.png`
  - Externally hosted match SFW: `https://i.imgur.com/IMyyE4e.jpg`
  - Externally hosted match NSFW: `https://pbs.twimg.com/media/D4zPJFZX4AECi9F.png`
    - ("Questionable" rating, not explicit, but not "safe" exactly)
  - Already on Derpibooru result: `https://derpicdn.net/img/view/2019/3/4/1977638.gif`

**TODOS:**
- Detect and shortcut the Derpibooru formatted URLs passed to `~reverse` to avoid reverse lookup.
- Cache `~reverse` lookup matches to avoid hitting Derpibooru's API.
- Add no-parameter `~reverse` command alias that uses Global/Channel state images instead of a user input URL.