### PR TITLE
Added dictionary for tracking nonDerpi links and NoArgReverse

### DIFF
--- a/Commands/derpiCommands.cs
+++ b/Commands/derpiCommands.cs
@@ -67,7 +67,19 @@ public class DerpibooruComms : ModuleBase<SocketCommandContext>
             }
         }
     }
-
+    [Command("reverse")]
+    [Alias("r")]
+    public async Task DerpiReverseNoArg()
+    {
+        if (Global.miscLinks.ContainsKey(Context.Channel.Id))
+        {
+            await DerpiReverse(Global.miscLinks[Context.Channel.Id]);
+        }
+        else
+        {
+            await ReplyAsync("There are no links in my memory! Post one first!");
+        }
+    }
     [Command("derpi")]
     [Alias("d")]
     public async Task DerpiDefault([Remainder]string search) {

--- a/Global.cs
+++ b/Global.cs
@@ -19,6 +19,7 @@ namespace CoreWaggles
         internal static Dictionary<ulong, string> searchesD = new Dictionary<ulong, string>();
         internal static Dictionary<ulong, string> links = new Dictionary<ulong, string>();
         internal static Dictionary<string, string> excomm = new Dictionary<string, string>();
+        internal static Dictionary<ulong, string> miscLinks = new Dictionary<ulong, string>();
         internal static int searched;
        internal static void checkURL(string srch, ulong id)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -152,6 +152,11 @@ namespace WagglesBot
                
 
             }
+            if(message.Content.ToLower().Contains("https://") && !message.Content.ToLower().Contains("https://derpi"))
+            {
+                var context = new SocketCommandContext(_client, message);
+                Global.miscLinks[context.Channel.Id] = message.Content;
+            }
             if (message.HasStringPrefix("~", ref argPos) && message.Author.Id != 141016540240805888 && !message.HasStringPrefix("~~", ref argPos))
             {
                 


### PR DESCRIPTION
Added Dictionary miscLinks to Globals, and a way to track non derpibooru links posted in chat, to be used in NoArgReverse command, much like NoArgDT.
-test by posting link and running ~reverse with no args afterward