### PR TITLE
Derpitags (~dt) Update

### DIFF
--- a/Commands/derpiCommands.cs
+++ b/Commands/derpiCommands.cs
@@ -467,7 +467,7 @@ public class DerpibooruComms : ModuleBase<SocketCommandContext>
         if (DerpiResponse.Search.Length < 1) {
             await ReplyAsync("No results found, please call `~derpi` again to get new results. Then I can fetch tags for you!");
         } else {
-             await DerpiTagsDisplay(DerpiResponse.Search[0]);
+             await DerpiTagsDisplay(DerpiResponse.Search[Global.searched - 1]);
         }
     }
 


### PR DESCRIPTION
Completely overhauled the ~dt methods. No discernable change in functionality.

**Testing Steps:**
- Try `~dt` without parameters. Should throw a friendly error if no `~derpi` searches were run on reboot yet.
- Try `~dt` after a `~derpi` search, to see if it can pull from the global cache alright.
- Test `~dt` with an integer ID, should get a result back.
- Test `~dt` with any sort of Derpibooru URL, should get a result back.
- Test `~dt` against any invalid inputs, should get a message back with no results.


Included is a new `DerpiTest` class with a static `ExtractBooruIdTest` function that will run through and test out a few scenarios and valid forms of Derpibooru image URLs to see if it can extract the ID's. Has one fail-case that should return -1.