### PR TITLE
~artist command update

### DIFF
--- a/Commands/derpiCommands.cs
+++ b/Commands/derpiCommands.cs
@@ -734,7 +734,7 @@ public class DerpiHelper {
                 break;
             default:
                 artistResult = artistAsLink 
-                    ? String.Join("\n", artistTags.Select(t => $"https://derpibooru.org/search?q={t}{safetySuffix}&filter_id=164610"))
+                    ? String.Join("\n", artistTags.Select(t => $"https://derpibooru.org/search?q={t.Trim()}{safetySuffix}&filter_id=164610"))
                     : String.Join(' ', artistTags);
                 break;
         }


### PR DESCRIPTION
**This branch is blocked by/depends on #15 **

This PR updates both the `~a` that tries to read the last Derpibooru link stored in `Global.links[]` as well as the one that takes a `~derpi` compatible search.

**Changes:**
- (More) Error message cases upon failure.
- `~a` considers SFW vs NSFW channels and references artists with the `safe` filter accordingly.

**Testing procedures:**
- Test if `~a` works as expected.
- Test `~a SEARCH_TERMS` works as expected.
- Double-check that artist-rendering tags still function properly, such as `~dt`.