### PR TITLE
Added wittyedit commands, allowing for the editing of existing wittys

### DIFF
--- a/CoreWaggles.csproj
+++ b/CoreWaggles.csproj
@@ -16,7 +16,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="JSONstorage\Wittys.JSON">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Keys.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
Added ability to change witty settings without deleting them entirely and reentering. Syntax isnt final, open to suggestions.
Commands:
~wittyedit <name/regex> <wittyName> <newName or newRegex>
~wittyedit probability <wittyName> <newProbability>
~wittyedit add response(s) <WittyName> <1+ responses wrapped in quotation marks>
~wittyedit remove response(s) <WittyName> <responseIndex>